### PR TITLE
Incorrect Center Panel Frame In Landscape

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -177,6 +177,10 @@ static char ja_kvoContext;
     [self styleContainer:self.centerPanelContainer animate:NO duration:0.0f];
 }
 
+- (void)viewDidAppear:(BOOL)animated{
+    [self _adjustCenterFrame]; //Account for possible rotation while view appearing
+}
+
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
 
 - (void)viewDidUnload {

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -178,6 +178,7 @@ static char ja_kvoContext;
 }
 
 - (void)viewDidAppear:(BOOL)animated{
+    [super viewDidAppear:animated];
     [self _adjustCenterFrame]; //Account for possible rotation while view appearing
 }
 


### PR DESCRIPTION
Setting the center panel frame in viewWillAppear does not guarantee a correctly oriented frame. Updated the frame in viewDidAppear so first pan will work with the correctly oriented frame.
