### PR TITLE
shouldAutorotate problem

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -208,9 +208,16 @@ static char ja_kvoContext;
         return YES;
     }
 }
-
-
 #endif
+
+- (BOOL)shouldAutorotate {
+    
+    [_centerPanel shouldAutorotate];
+    
+    return YES;
+}
+
+
 
 - (void)willAnimateRotationToInterfaceOrientation:(__unused UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
     self.centerPanelContainer.frame = [self _adjustCenterFrame];	


### PR DESCRIPTION
I had the problem that my viewcontroller on the centerpanel that rotates in the same view.
But when i used JaSidePanels, the function shouldAutorotate wasn't triggerd anymore. when i turned my device.
And its a app that's need to work on IOS 5 and 6

So first i have tried it with a superclass of uinavigation with no succes 
So then i have added this code in JASidePanelController.m
and that works fine for me.
