### PR TITLE
Enable or disable swipes from left and right

### DIFF
--- a/JASidePanels/Source/JASidePanelController.h
+++ b/JASidePanels/Source/JASidePanelController.h
@@ -148,6 +148,10 @@ typedef enum _JASidePanelState {
 @property (nonatomic, assign) BOOL allowRightOverpan; // defaults to YES
 @property (nonatomic, assign) BOOL allowLeftOverpan;  // defaults to YES
 
+// Determines whether or not the left or right panel can be swiped into view. Use if only way to view a panel is with a button
+@property (nonatomic, assign) BOOL allowLeftSwipe;  // defaults to YES
+@property (nonatomic, assign) BOOL allowRightSwipe; // defaults to YES
+
 // Containers for the panels.
 @property (nonatomic, strong, readonly) UIView *leftPanelContainer;
 @property (nonatomic, strong, readonly) UIView *rightPanelContainer;

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -394,7 +394,7 @@
                 buttonController = [nav.viewControllers objectAtIndex:0];
             }
         }
-        if (!buttonController.navigationItem.leftBarButtonItem) {
+        if (!buttonController.navigationItem.leftBarButtonItem) {   
             buttonController.navigationItem.leftBarButtonItem = [self leftButtonForCenterPanel];
         }
     }	

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -76,6 +76,8 @@ static char ja_kvoContext;
 @synthesize visiblePanel = _visiblePanel;
 @synthesize shouldDelegateAutorotateToVisiblePanel = _shouldDelegateAutorotateToVisiblePanel;
 @synthesize centerPanelHidden = _centerPanelHidden;
+@synthesize allowLeftSwipe = _allowLeftSwipe;
+@synthesize allowRightSwipe = _allowRightSwipe;
 
 #pragma mark - Icon
 
@@ -138,6 +140,8 @@ static char ja_kvoContext;
     self.allowRightOverpan = YES;
     self.bounceOnSidePanelOpen = YES;
     self.shouldDelegateAutorotateToVisiblePanel = YES;
+    self.allowRightSwipe = YES;
+    self.allowLeftSwipe = YES;
 }
 
 #pragma mark - UIViewController
@@ -438,6 +442,14 @@ static char ja_kvoContext;
     } else if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
         UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
         CGPoint translate = [pan translationInView:self.centerPanelContainer];
+        // determine if right swipe is allowed
+        if (translate.x < 0 && ! self.allowRightSwipe) {
+            return NO;
+        }
+        // determine if left swipe is allowed
+        if (translate.x > 0 && ! self.allowLeftSwipe) {
+            return NO;
+        }
         BOOL possible = translate.x != 0 && ((fabsf(translate.y) / fabsf(translate.x)) < 1.0f);
         if (possible && ((translate.x > 0 && self.leftPanel) || (translate.x < 0 && self.rightPanel))) {
             return YES;


### PR DESCRIPTION
Added two new properties following project conventions.

``` objc
@property (nonatomic, assign) BOOL allowLeftSwipe;  // defaults to YES
@property (nonatomic, assign) BOOL allowRightSwipe; // defaults to YES
```

In <code>-gestureRecognizerShouldBegin:</code> I added a check for the state of each property and the direction of the gesture to determine if the gesture should begin.

``` objc
// determine if right swipe is allowed
if (translate.x < 0 && ! self.allowRightSwipe) {
    return NO;
}
// determine if left swipe is allowed
if (translate.x > 0 && ! self.allowLeftSwipe) {
    return NO;
}
```

This is a pretty simple change that adds some functionality that I needed in my application. My usage was to have the right VC only be visible with selection of a button press, not a gesture. Other uses could be for disabling/enabling swipes during runtime.
