### PR TITLE
Renamed show methods to be more intuitive

### DIFF
--- a/JASidePanels.xcodeproj/project.pbxproj
+++ b/JASidePanels.xcodeproj/project.pbxproj
@@ -167,7 +167,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = JA;
-				LastUpgradeCheck = 0430;
+				LastUpgradeCheck = 0460;
 			};
 			buildConfigurationList = 9561ACA7151286EE005889C6 /* Build configuration list for PBXProject "JASidePanels" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -233,6 +233,10 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -259,6 +263,10 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/JASidePanels/Source/JASidePanelController.h
+++ b/JASidePanels/Source/JASidePanelController.h
@@ -46,6 +46,11 @@ typedef enum _JASidePanelState {
 @property (nonatomic, strong) UIViewController *rightPanel;  // optional
 
 // show the panels
+- (void)showLeftPanel:(BOOL)animated __attribute__((deprecated("Use -showLeftPanelAnimated: instead")));
+- (void)showRightPanel:(BOOL)animated __attribute__((deprecated("Use -showRightPanelAnimated: instead")));
+- (void)showCenterPanel:(BOOL)animated __attribute__((deprecated("Use -showCenterPanelAnimated: instead")));
+
+// show the panels
 - (void)showLeftPanelAnimated:(BOOL)animated;
 - (void)showRightPanelAnimated:(BOOL)animated;
 - (void)showCenterPanelAnimated:(BOOL)animated;

--- a/JASidePanels/Source/JASidePanelController.h
+++ b/JASidePanels/Source/JASidePanelController.h
@@ -46,9 +46,9 @@ typedef enum _JASidePanelState {
 @property (nonatomic, strong) UIViewController *rightPanel;  // optional
 
 // show the panels
-- (void)showLeftPanel:(BOOL)animated;
-- (void)showRightPanel:(BOOL)animated;
-- (void)showCenterPanel:(BOOL)animated;
+- (void)showLeftPanelAnimated:(BOOL)animated;
+- (void)showRightPanelAnimated:(BOOL)animated;
+- (void)showCenterPanelAnimated:(BOOL)animated;
 
 // toggle them opened/closed
 - (void)toggleLeftPanel:(id)sender;

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -888,6 +888,18 @@ static char ja_kvoContext;
     return [[UIBarButtonItem alloc] initWithImage:[[self class] defaultImage] style:UIBarButtonItemStylePlain target:self action:@selector(toggleLeftPanel:)];
 }
 
+- (void)showLeftPanel:(BOOL)animated {
+    [self showLeftPanelAnimated:animated];
+}
+
+- (void)showRightPanel:(BOOL)animated {
+    [self showRightPanelAnimated:animated];
+}
+
+- (void)showCenterPanel:(BOOL)animated {
+    [self showCenterPanelAnimated:animated];
+}
+
 - (void)showLeftPanelAnimated:(BOOL)animated {
     [self _showLeftPanel:animated bounce:NO];
 }

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -888,15 +888,15 @@ static char ja_kvoContext;
     return [[UIBarButtonItem alloc] initWithImage:[[self class] defaultImage] style:UIBarButtonItemStylePlain target:self action:@selector(toggleLeftPanel:)];
 }
 
-- (void)showLeftPanel:(BOOL)animated {
+- (void)showLeftPanelAnimated:(BOOL)animated {
     [self _showLeftPanel:animated bounce:NO];
 }
 
-- (void)showRightPanel:(BOOL)animated {
+- (void)showRightPanelAnimated:(BOOL)animated {
     [self _showRightPanel:animated bounce:NO];
 }
 
-- (void)showCenterPanel:(BOOL)animated {
+- (void)showCenterPanelAnimated:(BOOL)animated {
     // make sure center panel isn't hidden
     if (_centerPanelHidden) {
         _centerPanelHidden = NO;
@@ -947,9 +947,9 @@ static char ja_kvoContext;
             [self _unhideCenterPanel];
             [UIView animateWithDuration:duration animations:^{
                 if (self.state == JASidePanelLeftVisible) {
-                    [self showLeftPanel:NO];
+                    [self showLeftPanelAnimated:NO];
                 } else {
-                    [self showRightPanel:NO];
+                    [self showRightPanelAnimated:NO];
                 }
                 if (self.shouldResizeLeftPanel || self.shouldResizeRightPanel) {
                     [self _layoutSidePanels];

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -394,7 +394,7 @@
                 buttonController = [nav.viewControllers objectAtIndex:0];
             }
         }
-        if (!buttonController.navigationItem.leftBarButtonItem) {
+        if (!buttonController.navigationItem.leftBarButtonItem) {   
             buttonController.navigationItem.leftBarButtonItem = [self leftButtonForCenterPanel];
         }
     }	

--- a/README.markdown
+++ b/README.markdown
@@ -93,7 +93,7 @@ A UIViewController+JASidePanel category is included in the project. Usage is opt
 - (void)viewDidLoad {
     [super viewDidLoad];
     // sweet, I can access my parent JASidePanelController as a property!
-    [self.sidePanelController showCenterPanel:YES];
+    [self.sidePanelController showCenterPanelAnimated:YES];
 }
 
 @end


### PR DESCRIPTION
Minor change. Just a refactor, no logic change.

``` objc
// show the panels
- (void)showLeftPanelAnimated:(BOOL)animated;
- (void)showRightPanelAnimated:(BOOL)animated;
- (void)showCenterPanelAnimated:(BOOL)animated;
```

Reason being I nearly created more methods to choose whether or not to animate the changes. I assumed the <code>BOOL</code> was for choosing whether to show or hide the panels.
