### PR TITLE
Respect recognizesPanGesture property

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -469,6 +469,8 @@ static char ja_kvoContext;
 }
 
 - (void)_handlePan:(UIGestureRecognizer *)sender {
+    if (!self.recognizesPanGesture) return; // pretend we don't speak panGesture
+    
     if ([sender isKindOfClass:[UIPanGestureRecognizer class]]) {
         UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)sender;
         


### PR DESCRIPTION
Respect recognizesPanGesture property even if a UIPanGestureRecognizer has been added.

This allows us to dynamically alter wether to recognise pan gestures or not.

Specifically, I sometimes have childviewcontroller with another childviewcontroller that I display as an overlay. In this case, I want the user to make a choice in my overlayed viewcontroller, and disable panning. Once the overlayed viewcontroller is removed, panning is re-enabled.
