### PR TITLE
Fix leftVisibleWidth and rightVisibleWidth

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -130,6 +130,8 @@ static char ja_kvoContext;
 
 - (void)_baseInit {
     self.style = JASidePanelSingleActive;
+    self.leftFixedWidth = NAN;
+    self.rightFixedWidth = NAN;
     self.leftGapPercentage = 0.8f;
     self.rightGapPercentage = 0.8f;
     self.minimumMovePercentage = 0.15f;
@@ -762,7 +764,7 @@ static char ja_kvoContext;
     if (self.centerPanelHidden && self.shouldResizeLeftPanel) {
         return self.view.bounds.size.width;
     } else {
-        return self.leftFixedWidth ? self.leftFixedWidth : floorf(self.view.bounds.size.width * self.leftGapPercentage);
+        return self.leftFixedWidth == self.leftFixedWidth ? self.leftFixedWidth : floorf(self.view.bounds.size.width * self.leftGapPercentage);
     }
 }
 
@@ -770,7 +772,7 @@ static char ja_kvoContext;
     if (self.centerPanelHidden && self.shouldResizeRightPanel) {
         return self.view.bounds.size.width;
     } else {
-        return self.rightFixedWidth ? self.rightFixedWidth : floorf(self.view.bounds.size.width * self.rightGapPercentage);
+        return self.rightFixedWidth == self.rightFixedWidth ? self.rightFixedWidth : floorf(self.view.bounds.size.width * self.rightGapPercentage);
     }    
 }
 


### PR DESCRIPTION
Would always return 0 when left/rightFixedWidth not set.

This fix defaults the left/rightFixedWidth to NaN, and then tests to ensure an actual value is set before returning it.

The method that was being used doesn't work for floats (will always return true regardless)
