### PR TITLE
Don't reveal a non-existant panel through panning

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -485,6 +485,10 @@ static char ja_kvoContext;
         CGPoint translate = [pan translationInView:self.centerPanelContainer];
         CGRect frame = _centerPanelRestingFrame;
         frame.origin.x += [self _correctMovement:translate.x];
+        if ((frame.origin.x < 0.0f && !self.rightPanel) ||
+            (frame.origin.x > 0.0f && !self.leftPanel)) {
+            frame.origin.x = 0.0f;
+        }
         self.centerPanelContainer.frame = frame;
         
         // if center panel has focus, make sure correct side panel is revealed


### PR DESCRIPTION
If you keep panning to close an open panel, you'll see the panel on
the opposite side. That is fine if you have both panels. If you
have only a left panel or a right panel, but not both, there's
nothing to see on the opposite side. We restrict the gesture now so
you can't see beyond the center panel unless you have panels set
on both sides.

Thoughts? If there's a knob for this already, I couldn't find it.
