### PR TITLE
Add callbacks to panels before and after becoming active/inactive

### DIFF
--- a/JASidePanels/Demo/JADebugViewController.h
+++ b/JASidePanels/Demo/JADebugViewController.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "JASidePanelController.h"
 
-@interface JADebugViewController : UIViewController
+@interface JADebugViewController : UIViewController <JASidePanel>
 
 @end

--- a/JASidePanels/Demo/JADebugViewController.m
+++ b/JASidePanels/Demo/JADebugViewController.m
@@ -44,4 +44,24 @@
     NSLog(@"%@ didMoveToParentViewController %@", self, parent);
 }
 
+- (void)willBecomeActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce
+{
+    NSLog(@"%@ willBecomeActiveAsPanelAnimated:withBounce:", self);
+}
+
+- (void)didBecomeActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce
+{
+    NSLog(@"%@ didBecomeActiveAsPanelAnimated:withBounce:", self);
+}
+
+- (void)willResignActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce
+{
+    NSLog(@"%@ willResignActiveAsPanelAnimated:withBounce:", self);
+}
+
+- (void)didResignActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce
+{
+    NSLog(@"%@ didResignActiveAsPanelAnimated:withBounce:", self);
+}
+
 @end

--- a/JASidePanels/Source/JASidePanelController.h
+++ b/JASidePanels/Source/JASidePanelController.h
@@ -36,6 +36,18 @@ typedef enum _JASidePanelState {
     JASidePanelRightVisible
 } JASidePanelState;
 
+
+@protocol JASidePanel
+
+@optional
+- (void)willBecomeActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
+- (void)didBecomeActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
+- (void)willResignActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
+- (void)didResignActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
+
+@end
+
+
 @interface JASidePanelController : UIViewController<UIGestureRecognizerDelegate>
 
 #pragma mark - Usage


### PR DESCRIPTION
Added a protocol for panels that contains four optional methods:

```
- (void)willBecomeActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
- (void)didBecomeActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
- (void)willResignActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
- (void)didResignActiveAsPanelAnimated:(BOOL)animated withBounce:(BOOL)withBounce;
```

These are called (if the panel has implementation) in `_showRightPanel:bounce:`, `_showLeftPanel:bounce:` and `_showCenterPanel:bounce:`. This enables the side panel to be notified when the state changes.
