### PR TITLE
Crash when [_tapView removeFromSuperview] is called during pan gesture recognition

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -555,6 +555,7 @@ static char ja_kvoContext;
 
 - (void)setTapView:(UIView *)tapView {
     if (tapView != _tapView) {
+        _tapView.gestureRecognizers = nil;
         [_tapView removeFromSuperview];
         _tapView = tapView;
         if (_tapView) {


### PR DESCRIPTION
Fixes a crash that can occur if the center panel is shown programmatically while panning the center panel. In our implementation this can be reproduced by tapping an item in the sidebar menu while panning the center panel; tapping the menu item closes the menu by calling `showCenterPanelAnimated:`.

It appears that the pan gesture recognizer can be triggered after the `tapView` is removed from its subview and subsequently deallocated, causing a null pointer dereference within the UIKit framework. The solution is to remove the gesture recognizers on the view before removing it from its superview. 

There are a few other instances where `removeFromSuperview` is used, though since we do not use those particular features I am not able to verify whether the same change needs to be made there.
