### PR TITLE
Fixes a few of the slide animations speeds

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -781,6 +781,7 @@ static char ja_kvoContext;
 		}
     }
     _centerPanelRestingFrame = frame;
+    _locationBeforePan = _centerPanelRestingFrame.origin;
     return _centerPanelRestingFrame;
 }
 


### PR DESCRIPTION
Fixes the case where, while in the demo, you're viewing the right side panel and you drag the center panel almost to the end. The animation moves too fast (in my opinion).

Fixes a case where bounce is disabled and you get to a side panel by way of the showRightPanelAnimated:YES method. When you hide the center panel (so that you can go deeper into the navigation), the animation to hide the center panel is extremely fast. This could be a very edge case, as it doesn't happen in the demo.

I'm not positive this is the best way or that it doesn't have unintended side-effects, but it does fix the issue that we were experiencing (namely the 2nd one listed here).
