### PR TITLE
Animate the shadow when the center panel hides or unhides

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -990,6 +990,12 @@ static char ja_kvoContext;
         _centerPanelHidden = centerPanelHidden;
         duration = animated ? duration : 0.0f;
         if (centerPanelHidden) {
+            CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"shadowOpacity"];
+			animation.fromValue = [NSNumber numberWithFloat:0.75f];
+			animation.toValue = [NSNumber numberWithFloat:0.0f];
+			animation.duration = duration;
+			[self.centerPanelContainer.layer addAnimation:animation forKey:@"shadowOpacity"];
+			self.centerPanelContainer.layer.shadowOpacity = 0.0f;
             [UIView animateWithDuration:duration animations:^{
                 CGRect frame = self.centerPanelContainer.frame;
                 frame.origin.x = self.state == JASidePanelLeftVisible ? self.centerPanelContainer.frame.size.width : -self.centerPanelContainer.frame.size.width;
@@ -1004,6 +1010,12 @@ static char ja_kvoContext;
                 }
             }];
         } else {
+            CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"shadowOpacity"];
+			animation.fromValue = [NSNumber numberWithFloat:0.0f];
+			animation.toValue = [NSNumber numberWithFloat:0.75f];
+			animation.duration = duration;
+			[self.centerPanelContainer.layer addAnimation:animation forKey:@"shadowOpacity"];
+			self.centerPanelContainer.layer.shadowOpacity = 0.75f;
             [self _unhideCenterPanel];
             [UIView animateWithDuration:duration animations:^{
                 if (self.state == JASidePanelLeftVisible) {


### PR DESCRIPTION
- Open the demo project
- Run the app in the iOS simulator
- Activate Debug/Toggle Slow Animations
- Click the navigation bar button and then Hide Center
- Then click on Show Center

The shadow doesn't animate. It disappears immediately and then pops into existence out of nowhere. This small patch animates them when the center is hidden or unhidden.
