### PR TITLE
Fix unintentional wait if bounce is disabled

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -354,23 +354,31 @@ static char ja_kvoContext;
             self.visiblePanel = _centerPanel;
         }
     }
+
     if (self.isViewLoaded && self.state == JASidePanelCenterVisible) {
         [self _swapCenter:previous previousState:0 with:_centerPanel];
     } else if (self.isViewLoaded) {
         // update the state immediately to prevent user interaction on the side panels while animating
         JASidePanelState previousState = self.state;
         self.state = JASidePanelCenterVisible;
-        [UIView animateWithDuration:0.2f animations:^{
-            if (self.bounceOnCenterPanelChange) {
+
+        void (^completion)(BOOL) = ^(__unused BOOL finished) {
+            [self _swapCenter:previous previousState:previousState with:_centerPanel];
+            [self _showCenterPanel:YES bounce:NO];
+        };
+
+        if (self.bounceOnCenterPanelChange) {
+            [UIView animateWithDuration:0.2f
+                             animations:^{
                 // first move the centerPanel offscreen
                 CGFloat x = (previousState == JASidePanelLeftVisible) ? self.view.bounds.size.width : -self.view.bounds.size.width;
                 _centerPanelRestingFrame.origin.x = x;
-            }
-            self.centerPanelContainer.frame = _centerPanelRestingFrame;
-        } completion:^(__unused BOOL finished) {
-            [self _swapCenter:previous previousState:previousState with:_centerPanel];
-            [self _showCenterPanel:YES bounce:NO];
-        }];
+                self.centerPanelContainer.frame = _centerPanelRestingFrame;
+            } completion:completion];
+        } else {
+            completion(YES);
+        }
+
     }
 }
 


### PR DESCRIPTION
- **Summary**: If `bounceOnCenterPanelChange` is disabled and the center panel is still performing animations, the change of the center panel is not immediate, but waits until animations are completed.
- **Steps to Reproduce**: 
  - Create center panel with scroll view
  - Run application and flick scroll view in center panel
  - Call `setCenterPanel` while scroll view is still scrolling
- **Actual Results**: Center panel is changed after (unrelated) animations are finished, e.g., scroll view is still animating the scroll
- **Expected Results**: Center panel should be changed immediately
- **Cause**: `setCenterPanel` is using `UIView.animateWithDuration`, but the `animations` block performs no changes if `bounceOnCenterPanelChange` is false. The `animations` block is thus empty and the `completion` block fires after unrelated animations are comleted.
- **Fix**: Don't use  `UIView.animateWithDuration` if `bounceOnCenterPanelChange` is false,  perform actions of completion block immediately. 
