### PR TITLE
added possibility to add pan gestures to left and right panel

### DIFF
--- a/JASidePanels/Source/JASidePanelController.h
+++ b/JASidePanels/Source/JASidePanelController.h
@@ -125,6 +125,12 @@ typedef enum _JASidePanelState {
 // Determines whether showing panels can be controlled through pan gestures, or only through buttons
 @property (nonatomic) BOOL recognizesPanGesture; // default is YES
 
+// Determines whether showing center panel can be controller through pan gestures on the left view. Requires recognizesPanGesture = YES
+@property (nonatomic) BOOL recognizesLeftViewPanGesture; // default is NO
+
+// Determines whether showing center panel can be controller through pan gestures on the right view. Requires recognizesPanGesture = YES
+@property (nonatomic) BOOL recognizesRightViewPanGesture; // default is NO
+
 #pragma mark - Menu Buttons
 
 // Gives you an image to use for your menu button. The image is three stacked white lines, similar to Path 2.0 or Facebook's menu button.

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -140,6 +140,8 @@ static char ja_kvoContext;
     self.bouncePercentage = 0.075f;
     self.panningLimitedToTopViewController = YES;
     self.recognizesPanGesture = YES;
+    self.recognizesLeftViewPanGesture = NO;
+    self.recognizesRightViewPanGesture = NO;
     self.allowLeftOverpan = YES;
     self.allowRightOverpan = YES;
     self.bounceOnSidePanelOpen = YES;
@@ -448,7 +450,7 @@ static char ja_kvoContext;
 #pragma mark - Gesture Recognizer Delegate
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-    if (gestureRecognizer.view == self.tapView) {
+    if (gestureRecognizer.view == self.tapView || gestureRecognizer.view == self.rightPanel.view || gestureRecognizer.view == self.leftPanel.view) {
         return YES;
     } else if (self.panningLimitedToTopViewController && ![self _isOnTopLevelViewController:self.centerPanel]) {
         return NO;
@@ -691,6 +693,10 @@ static char ja_kvoContext;
             _leftPanel.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
             [self stylePanel:_leftPanel.view];
             [self.leftPanelContainer addSubview:_leftPanel.view];
+            
+            if (self.recognizesLeftViewPanGesture) {
+                [self _addPanGestureToView:self.leftPanel.view];
+            }
         }
         
         self.leftPanelContainer.hidden = NO;
@@ -706,6 +712,10 @@ static char ja_kvoContext;
             _rightPanel.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
             [self stylePanel:_rightPanel.view];
             [self.rightPanelContainer addSubview:_rightPanel.view];
+            
+            if (self.recognizesRightViewPanGesture) {
+                [self _addPanGestureToView:self.rightPanel.view];
+            }
         }
         
         self.rightPanelContainer.hidden = NO;


### PR DESCRIPTION
Two new properties:

```
recognizesLeftViewPanGesture
recognizesLeftViewPanGesture
```

If set to `YES`, it will allow the user to close the left or right
panel by pan gestures on the corresponding view. Can be useful if a panel is filling the entire screen so that the centerpanel cannot be "dragged" or closed by tapping the menu button.
