### PR TITLE
Fix for centerPanel animation

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -738,7 +738,7 @@ static char ja_kvoContext;
     }
     
     CGFloat duration = [self _calculatedDuration];
-    [UIView animateWithDuration:duration delay:0.0f options:UIViewAnimationOptionCurveLinear|UIViewAnimationOptionLayoutSubviews animations:^{
+    [UIView animateWithDuration:duration delay:0.0f options:UIViewAnimationOptionCurveLinear|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState animations:^{
         self.centerPanelContainer.frame = _centerPanelRestingFrame;
         [self styleContainer:self.centerPanelContainer animate:YES duration:duration];
         if (self.style == JASidePanelMultipleActive || self.pushesSidePanels) {


### PR DESCRIPTION
Added `UIViewAnimationOptionBeginFromCurrentState` when animating
the centerPanel. This fixes glitchy behavior when there is a `UIToolbar` in the centerPanel with a overridden `layoutSubviews`. Without this option the buttons in the `UIToolbar` would be jumping around before animating into place. It could probably fix animation problems in other subviews with overridden `layoutSubviews` as well.
