### PR TITLE
A simple fix for the iOS7 Status Bar issue. 

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -228,7 +228,7 @@ static char ja_kvoContext;
 #endif
 
 - (void)willAnimateRotationToInterfaceOrientation:(__unused UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
-    self.centerPanelContainer.frame = [self _adjustCenterFrame];	
+    self.centerPanelContainer.frame = [self _adjustCenterFrame];
     [self _layoutSideContainers:YES duration:duration];
     [self _layoutSidePanels];
     [self styleContainer:self.centerPanelContainer animate:YES duration:duration];
@@ -308,6 +308,12 @@ static char ja_kvoContext;
 - (void)_layoutSideContainers:(BOOL)animate duration:(NSTimeInterval)duration {
     CGRect leftFrame = self.view.bounds;
     CGRect rightFrame = self.view.bounds;
+    
+    if (![UIApplication sharedApplication].statusBarHidden) {
+        leftFrame.origin.y = leftFrame.origin.y + [UIApplication sharedApplication].statusBarFrame.size.height;
+        rightFrame.origin.y = rightFrame.origin.y + [UIApplication sharedApplication].statusBarFrame.size.height;
+    }
+    
     if (self.style == JASidePanelMultipleActive) {
         // left panel container
         leftFrame.size.width = self.leftVisibleWidth;
@@ -774,6 +780,10 @@ static char ja_kvoContext;
 
 - (CGRect)_adjustCenterFrame {
     CGRect frame = self.view.bounds;
+    if (![UIApplication sharedApplication].statusBarHidden) {
+        frame.origin.y = frame.origin.y + [UIApplication sharedApplication].statusBarFrame.size.height;
+    }
+    
     switch (self.state) {
         case JASidePanelCenterVisible: {
             frame.origin.x = 0.0f;


### PR DESCRIPTION
It moves the JASidePanelController views down by the height of the status bar _only if the status bar is visible_. Tested this against iOS7 and iOS6. Doesn't break anything. Fixes #162
