### PR TITLE
fixed rightpanel overlapping leftpanel issue

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -601,6 +601,10 @@ static char ja_kvoContext;
     if (self.state == JASidePanelCenterVisible) {
         if ((position > 0.0f && !self.leftPanel) || (position < 0.0f && !self.rightPanel)) {
             return 0.0f;
+        } else if (!self.pushesSidePanels && position > 0.0f && self.rightPanel && !self.rightPanelContainer.hidden) {
+            return 0.0f;
+        } else if (!self.pushesSidePanels && position < 0.0f && self.leftPanel && !self.leftPanelContainer.hidden) {
+            return 0.0f;
         } else if (!self.allowLeftOverpan && position > self.leftVisibleWidth) {
             return self.leftVisibleWidth;
         } else if (!self.allowRightOverpan && position < -self.rightVisibleWidth) {


### PR DESCRIPTION
If the user starts dragging the center panel to show the right panel, but then drags the other way to show the left panel, the right panel would be visible on the left side, overlapping the left panel until the user let go of the center panel. 

This pull request fixes that issue by preventing the user to start dragging the center panel in one direction and then dragging it the other way.
