### PR TITLE
Added possibility to respond to when the sidepanels move/pan

### DIFF
--- a/JASidePanels/Source/JASidePanelController.h
+++ b/JASidePanels/Source/JASidePanelController.h
@@ -94,6 +94,9 @@ typedef enum _JASidePanelState {
 // by default applies rounded corners to the panel. override in sublcass to change
 - (void)stylePanel:(UIView *)panel;
 
+// This method will be called whenever the sidepanel visible amount change. Subclass this method to react to changes of how much of the center panel / side panels are visible
+- (void)willPanToSidePanelVisiblePercent:(CGFloat)percent duration:(CGFloat)duration;
+
 #pragma mark - Animation
 
 // the minimum % of total screen width the centerPanel.view must move for panGesture to succeed

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -516,8 +516,10 @@ static char ja_kvoContext;
         if (self.style == JASidePanelMultipleActive || self.pushesSidePanels) {
             [self _layoutSideContainers:NO duration:0];
         }
-        
-        if (sender.state == UIGestureRecognizerStateEnded) {
+        if(sender.state == UIGestureRecognizerStateChanged) {
+            CGFloat fullyVisibleWidth = frame.origin.x > 0.0f ? self.leftVisibleWidth : -self.rightVisibleWidth;
+            [self willPanToSidePanelVisiblePercent:(frame.origin.x / fullyVisibleWidth) duration:0.0f];
+        } else if (sender.state == UIGestureRecognizerStateEnded) {
             CGFloat deltaX =  frame.origin.x - _locationBeforePan.x;			
             if ([self _validateThreshold:deltaX]) {
                 [self _completePan:deltaX];
@@ -566,6 +568,8 @@ static char ja_kvoContext;
 		}
     }
 }
+
+- (void)willPanToSidePanelVisiblePercent:(CGFloat)percent duration:(CGFloat)duration {}
 
 #pragma mark - Tap Gesture
 
@@ -738,6 +742,8 @@ static char ja_kvoContext;
     }
     
     CGFloat duration = [self _calculatedDuration];
+    CGFloat sidePanelVisiblePercent = _centerPanelRestingFrame.origin.x == 0.0f ? 0.0f : 1.0f;
+    [self willPanToSidePanelVisiblePercent:sidePanelVisiblePercent duration:duration];
     [UIView animateWithDuration:duration delay:0.0f options:UIViewAnimationOptionCurveLinear|UIViewAnimationOptionLayoutSubviews animations:^{
         self.centerPanelContainer.frame = _centerPanelRestingFrame;
         [self styleContainer:self.centerPanelContainer animate:YES duration:duration];
@@ -829,6 +835,7 @@ static char ja_kvoContext;
     if (animated) {
         [self _animateCenterPanel:shouldBounce completion:nil];
     } else {
+        [self willPanToSidePanelVisiblePercent:1.0f duration:0.0f];
         self.centerPanelContainer.frame = _centerPanelRestingFrame;	
         [self styleContainer:self.centerPanelContainer animate:NO duration:0.0f];
         if (self.style == JASidePanelMultipleActive || self.pushesSidePanels) {
@@ -851,6 +858,7 @@ static char ja_kvoContext;
     if (animated) {
         [self _animateCenterPanel:shouldBounce completion:nil];
     } else {
+        [self willPanToSidePanelVisiblePercent:1.0f duration:0.0f];
         self.centerPanelContainer.frame = _centerPanelRestingFrame;	
         [self styleContainer:self.centerPanelContainer animate:NO duration:0.0f];
         if (self.style == JASidePanelMultipleActive || self.pushesSidePanels) {
@@ -876,6 +884,7 @@ static char ja_kvoContext;
             [self _unloadPanels];
         }];
     } else {
+        [self willPanToSidePanelVisiblePercent:0.0f duration:0.0f];
         self.centerPanelContainer.frame = _centerPanelRestingFrame;	
         [self styleContainer:self.centerPanelContainer animate:NO duration:0.0f];
         if (self.style == JASidePanelMultipleActive || self.pushesSidePanels) {


### PR DESCRIPTION
Added public method:
`- (void)willPanToSidePanelVisiblePercent:(CGFloat)percent duration:(CGFloat)duration`

This method gets called whenever the sidepanels moves.
Overriding this method in your JASidePanelController subclass allows you to respond to pan changes with fine grained control.
I needed this to be able to fade the background of the status bar to opaque black in iOS7 when the centerPanel gets panned to either side (Like Facebook does on iOS7)

Video for clarity: http://youtu.be/5T2YV_hl7S0
