### PR TITLE
subclasses from .xib-files initWithNibName fix

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -123,6 +123,15 @@ static char ja_kvoContext;
     return self;
 }
 
+//Support subclasses from .xib-files
+- (id) initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    if (self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]) {
+        [self _baseInit];
+    }
+    return self;
+}
+
 - (id)init {
     if (self = [super init]) {
         [self _baseInit];


### PR DESCRIPTION
Hi! I've added _baseInit call on initWithNibName. Addition JASidePanels-subclass as an implementation of class with xib-file fixed. It was unexpected to find out different behavior for subclassing and for composition of classes.
