### PR TITLE
- added preferred status bar style bubble-through

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -1040,4 +1040,11 @@ static char ja_kvoContext;
     }
 }
 
+-(UIStatusBarStyle)preferredStatusBarStyle {
+	if([_centerPanel isKindOfClass:[UINavigationController class]]) {
+		return [[(UINavigationController*)_centerPanel topViewController] preferredStatusBarStyle];
+	}
+    return [_centerPanel preferredStatusBarStyle];
+}
+
 @end


### PR DESCRIPTION
If I want to use different status bar style in different center controllers within navigation stack, I need to respond to preferredStatusBarStyle method, but JASidePanelController doesn't let me do it if I am using UINavigationController. Proposed fix is just rough idea, I am not really sure if there are some cases where this would fail or if there is more elegant solution
