### PR TITLE
Add JASidePanels.podspec

### DIFF
--- a/JASidePanels.podspec
+++ b/JASidePanels.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         =  'JASidePanels'
+  s.version      =  '1.3.2'
+  s.license      =  { :type => 'MIT', :file => 'README.markdown' }
+  s.summary      =  'UIViewController container designed for presenting a center panel with revealable side panels - one to the left and one to the right.'
+  s.homepage     =  'https://github.com/gotosleep/JASidePanels'
+  s.author       =  { 'Jesse Andersen' => 'gotosleep@gmail.com' }
+  s.source       =  { :git => 'https://github.com/gotosleep/JASidePanels.git', :tag => '1.3.2' }
+  s.platform     =  :ios, '5.0'
+  s.source_files =  'JASidePanels/Source/*'
+  s.framework    =  'QuartzCore'
+  s.requires_arc =  true
+end


### PR DESCRIPTION
Hi,

This PR makes it easier for your end users to reference a fork of JASidePanels from their podfile. It does so by adding a podspec to the JASidePanels repository.

For example:

``` ruby
pod 'JASidePanels', :git => 'https://github.com/pierlis/JASidePanels.git', :commit => 'e3e162f51f2517cdf66d871d6bcf657a18199f88'
```

Without the podspec, the `pod` command can not reference a specific commit. And this is not handy, whenever a fork is still a work in progress. This is what is fixed by this PR.

NB: if you accept this PR, you will have to maintain this file, and keep it in sync with the spec published on the http://cocoapods.org website.
