### PR TITLE
Dismiss any open keyboards when changing state

### DIFF
--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -243,6 +243,7 @@ static char ja_kvoContext;
 
 - (void)setState:(JASidePanelState)state {
     if (state != _state) {
+        [[UIApplication sharedApplication] sendAction:@selector(resignFirstResponder) to:nil from:nil forEvent:nil];
         _state = state;
         switch (_state) {
             case JASidePanelCenterVisible: {


### PR DESCRIPTION
Uses a solution found on the interwebs for globally dismissing open keyboards when you don't have the exact view to resign first responder on.
