### PR TITLE
Add support for accessibility label on menu button

### DIFF
--- a/JASidePanels/Source/JASidePanelController.h
+++ b/JASidePanels/Source/JASidePanelController.h
@@ -44,6 +44,7 @@ typedef enum _JASidePanelState {
 @property (nonatomic, strong) UIViewController *leftPanel;   // optional
 @property (nonatomic, strong) UIViewController *centerPanel; // required
 @property (nonatomic, strong) UIViewController *rightPanel;  // optional
+@property (nonatomic, copy)   NSString *leftButtonForCenterPanelAccessibilityLabel; // optional, e.g. "Main Menu"
 
 // show the panels
 - (void)showLeftPanel:(BOOL)animated __attribute__((deprecated("Use -showLeftPanelAnimated: instead")));

--- a/JASidePanels/Source/JASidePanelController.m
+++ b/JASidePanels/Source/JASidePanelController.m
@@ -49,6 +49,7 @@ static char ja_kvoContext;
 @synthesize leftPanelContainer = _leftPanelContainer;
 @synthesize rightPanelContainer = _rightPanelContainer;
 @synthesize centerPanelContainer = _centerPanelContainer;
+@synthesize leftButtonForCenterPanelAccessibilityLabel = _leftButtonForCenterPanelAccessibilityLabel;
 @synthesize tapView = _tapView;
 @synthesize style = _style;
 @synthesize state = _state;
@@ -953,7 +954,9 @@ static char ja_kvoContext;
 #pragma mark - Public Methods
 
 - (UIBarButtonItem *)leftButtonForCenterPanel {
-    return [[UIBarButtonItem alloc] initWithImage:[[self class] defaultImage] style:UIBarButtonItemStylePlain target:self action:@selector(toggleLeftPanel:)];
+    UIBarButtonItem *leftButton = [[UIBarButtonItem alloc] initWithImage:[[self class] defaultImage] style:UIBarButtonItemStylePlain target:self action:@selector(toggleLeftPanel:)];
+    leftButton.accessibilityLabel = _leftButtonForCenterPanelAccessibilityLabel;
+    return leftButton;
 }
 
 - (void)showLeftPanel:(BOOL)animated {


### PR DESCRIPTION
Current version does not implement it, right now the accessibility label just says "Button" without any context / information. In our application I've set this value to "Main Menu".
